### PR TITLE
Add docstrings and generic request exception handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+OMNI_API_KEY=<<your api key>>
+OMNI_BASE_URL=<<your base url>>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,10 @@ from omni_python_sdk import OmniAPI
 
 # Set your API key and base URL
 api_key = "your_api_key"
-base_url = "https://your_domain.omniapp.co/api/unstable"
+base_url = "https://your_domain.omniapp.co"
+#these can optionally be set in an .env file with the following keys:
+# OMNI_API_KEY=<<your api key>>
+# OMNI_BASE_URL=<<your base url>>
 
 # Define your query
 query = {
@@ -37,6 +40,10 @@ query = {
 
 # Initialize the API with your credentials
 api = OmniAPI(api_key, base_url)
+# if you've optionally set your keys in a .env file no arguments are required:
+# api = OmniAPI()
+# if your environment variables are stored in an alternative location
+# api = OmniAPI(env_file='<<path_to_custom_env>>')
 
 # Run the query and get a table
 table = api.run_query_blocking(query)
@@ -55,5 +62,5 @@ To get a query object, you can use the Inspector on a Omni Workbook. The query o
 For a simple command line interface, you can run the following command:
 
 ```bash
-python3 examples/query.py OMNI_API_KEY https://OMNI_URL/api/unstable '{"query": {"sorts": [{"column_name": "omni_dbt__order_items.created_at[date]", "sort_descending": false}], "table": "omni_dbt__order_items", "fields": ["omni_dbt__order_items.created_at[date]", "omni_dbt__order_items.total_sale_price"], "modelId": "OMNI_MODEL_ID", "join_paths_from_topic_name": "order_items"}}
+python3 examples/query.py OMNI_API_KEY https://OMNI_URL '{"query": {"sorts": [{"column_name": "omni_dbt__order_items.created_at[date]", "sort_descending": false}], "table": "omni_dbt__order_items", "fields": ["omni_dbt__order_items.created_at[date]", "omni_dbt__order_items.total_sale_price"], "modelId": "OMNI_MODEL_ID", "join_paths_from_topic_name": "order_items"}}
 ```

--- a/examples/user_management/user_management.py
+++ b/examples/user_management/user_management.py
@@ -8,7 +8,6 @@ base_url = 'https://<<your omni host>>'
 # Initialize the API with your credentials
 api = OmniAPI(api_key, base_url)
 
-
 with open('users.csv', newline='') as csvfile:
     spamreader = csv.DictReader(csvfile)
     for row in spamreader:

--- a/examples/user_management/users.csv
+++ b/examples/user_management/users.csv
@@ -1,4 +1,4 @@
 op,email,display_name,is_admin,regions
 upsert,example@omni.co,"Omni Example",true,"[north,south,east]"
-upsert,example@omni.co,"Omni Example",true,"[north,south,east]"
-delete,example3@omni.co,"Omni Example 2",true,"[west]"
+upsert,example2@omni.co,"Omni Example 2",true,"[north,south,east]"
+delete,example3@omni.co,"Omni Example 3",true,"[west]"

--- a/omni_python_sdk/api.py
+++ b/omni_python_sdk/api.py
@@ -6,7 +6,9 @@ import urllib.parse
 import json
 import ndjson
 import base64
-from typing import List, Tuple, Any
+from typing import List, Tuple, Any, Union
+import os
+from dotenv import load_dotenv
 import functools
 
 def requests_error_handler(func):
@@ -37,32 +39,37 @@ def requests_error_handler(func):
     return wrapper
 
 class OmniAPI:
-    """
-    A class to interact with the Omni API.
-
-    This class provides methods to perform various operations such as running queries,
-    managing models, topics, views, fields, and users.
-
-    Attributes:
-        api_key (str): The API key for authentication.
-        base_url (str): The base URL for the API.
-        headers (dict): The headers used for API requests.
-    """
-
-    def __init__(self, api_key: str, base_url: str = "https://dev.thundersalmon.com/api/unstable"):
-        """
-        Initialize the OmniAPI instance.
-        Args:
-            api_key (str): The API key for authentication.
-            base_url (str, optional): The base URL for the API. Defaults to "https://dev.thundersalmon.com/api/unstable".
-        """
-        self.api_key = api_key
-        self.base_url = base_url
+    def __init__(self, api_key: str = '', base_url: str = "https://dev.thundersalmon.com",env_file: str = '.env'):
+        if load_dotenv(dotenv_path=env_file):
+            if os.getenv('OMNI_API_KEY'):
+                self.api_key = os.getenv('OMNI_API_KEY')
+            else:
+                self.api_key = api_key
+            if os.getenv('OMNI_BASE_URL'):
+                self.base_url = os.getenv('OMNI_BASE_URL')
+            else: 
+                self.base_url = base_url
+        self._trim_base_url()
         self.headers = {
             'Authorization': f'Bearer {self.api_key}',
             'Content-Type': 'application/json'
         }
 
+    def _trim_base_url(self) -> None:
+        '''
+        Trims the base_url to remove any trailing slashes or api versions
+        since the versioning of an endpoint is managed by the SDK methods,
+        and varies between endpoints
+        '''
+        if self.base_url.endswith('/'):
+            self.base_url = self.base_url[:-1]
+        if self.base_url.endswith('/api/v1'):
+            self.base_url = self.base_url[:-7]
+        if self.base_url.endswith('/api'):
+            self.base_url = self.base_url[:-4]
+        if self.base_url.endswith('/api/unstable'):
+            self.base_url = self.base_url[:-13]
+            
     @requests_error_handler
     def wait_query_blocking(self, remaining_job_ids: List[str]) -> Tuple[Any, bool]:
         """
@@ -74,7 +81,11 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = f"{self.base_url}/query/wait"
+        '''
+        remaining_job_ids: List[str] - the list of job ids to wait for
+        Wait for a query to complete by providing a list of job ids.
+        '''
+        url = f"{self.base_url}/api/unstable/query/wait"
         
         # URL encode the query parameter
         encoded_query = urllib.parse.urlencode({'job_ids': json.dumps(remaining_job_ids)})
@@ -101,7 +112,7 @@ class OmniAPI:
             ValueError: If no result is found in the response.
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = f"{self.base_url}/query/run"
+        url = f"{self.base_url}/api/unstable/query/run"
         response = requests.post(url, headers=self.headers, json=body)
     
         if response.status_code == 200:
@@ -125,15 +136,15 @@ class OmniAPI:
         else:
             response.raise_for_status()
 
-    def base_model_url(self) -> str:
+    def _base_model_url(self) -> str:
         """
         Get the base URL for model operations.
         Returns:
             str: The base URL for model operations.
         """
-        return f"{self.base_url}/model"
+        return f"{self.base_url}/api/unstable/model"
 
-    def model_url(self, model_id: str) -> str:
+    def _model_url(self, model_id: str) -> str:
         """
         Get the URL for a specific model.
         Args:
@@ -141,9 +152,9 @@ class OmniAPI:
         Returns:
             str: The URL for the specified model.
         """
-        return f"{self.base_model_url()}/{model_id}"
+        return f"{self._base_model_url()}/{model_id}"
 
-    def base_topic_url(self, model_id: str) -> str:
+    def _base_topic_url(self, model_id: str) -> str:
         """
         Get the base URL for topic operations.
         Args:
@@ -151,9 +162,9 @@ class OmniAPI:
         Returns:
             str: The base URL for topic operations.
         """
-        return f"{self.base_model_url()}/{model_id}/topic"
+        return f"{self._model_url(model_id)}/topic"
 
-    def topic_url(self, model_id: str, topic_name: str) -> str:
+    def _topic_url(self, model_id: str, topic_name: str) -> str:
         """
         Get the URL for a specific topic.
         Args:
@@ -162,9 +173,9 @@ class OmniAPI:
         Returns:
             str: The URL for the specified topic.
         """
-        return f"{self.base_topic_url(model_id)}/{topic_name}"
+        return f"{self._base_topic_url(model_id)}/{topic_name}"
 
-    def base_view_url(self, model_id: str) -> str:
+    def _base_view_url(self, model_id: str) -> str:
         """
         Get the base URL for view operations.
         Args:
@@ -172,9 +183,9 @@ class OmniAPI:
         Returns:
             str: The base URL for view operations.
         """
-        return f"{self.base_model_url()}/{model_id}/view"
+        return f"{self._base_model_url()}/{model_id}/view"
 
-    def view_url(self, model_id: str, view_name: str) -> str:
+    def _view_url(self, model_id: str, view_name: str) -> str:
         """
         Get the URL for a specific view.
         Args:
@@ -183,9 +194,9 @@ class OmniAPI:
         Returns:
             str: The URL for the specified view.
         """
-        return f"{self.base_view_url(model_id)}/{view_name}"
+        return f"{self._base_model_url(model_id)}/{view_name}"
 
-    def base_field_url(self, model_id: str) -> str:
+    def _base_field_url(self, model_id: str) -> str:
         """
         Get the base URL for field operations.
         Args:
@@ -193,9 +204,9 @@ class OmniAPI:
         Returns:
             str: The base URL for field operations.
         """
-        return f"{self.base_view_url(model_id)}/field"
+        return f"{self._base_view_url(model_id)}/field"
 
-    def field_url(self, model_id: str, view_name: str, field_name: str) -> str:
+    def _field_url(self, model_id: str, view_name: str, field_name: str) -> str:
         """
         Get the URL for a specific field.
         Args:
@@ -205,7 +216,7 @@ class OmniAPI:
         Returns:
             str: The URL for the specified field.
         """
-        return f"{self.view_url(model_id, view_name)}/field/{field_name}"
+        return f"{self._view_url(model_id, view_name)}/field/{field_name}"
     
     @requests_error_handler
     def create_model(self, connection_id: str, body: dict) -> dict:
@@ -219,7 +230,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.base_model_url()
+        url = self._base_model_url()
         body["connectionId"] = connection_id
         response = requests.post(url, headers=self.headers, json=body)
         response.raise_for_status()
@@ -238,7 +249,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.base_topic_url(model_id)
+        url = self._base_topic_url(model_id)
         body["baseViewName"] = base_view_name
         response = requests.post(url, headers=self.headers, json=body)
         response.raise_for_status()
@@ -257,7 +268,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.topic_url(model_id, topic_name)
+        url = self._topic_url(model_id, topic_name)
         response = requests.patch(url, headers=self.headers, json=body)
         response.raise_for_status()
         return response.json()
@@ -274,7 +285,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.topic_url(model_id, topic_name)
+        url = self._topic_url(model_id, topic_name)
         response = requests.delete(url, headers=self.headers)
         response.raise_for_status()
         return response.json()
@@ -292,7 +303,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.base_view_url(model_id)
+        url = self._base_view_url(model_id)
         body["viewName"] = view_name
         response = requests.post(url, headers=self.headers, json=body)
         response.raise_for_status()
@@ -311,7 +322,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.view_url(model_id, view_name)
+        url = self._view_url(model_id, view_name)
         body["viewName"] = view_name
         response = requests.patch(url, headers=self.headers, json=body)
         response.raise_for_status()
@@ -329,7 +340,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.view_url(model_id, view_name)
+        url = self._view_url(model_id, view_name)
         response = requests.delete(url, headers=self.headers)
         response.raise_for_status()
         return response.json()
@@ -348,7 +359,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.base_field_url(model_id)
+        url = self._base_field_url(model_id)
         body["fieldName"] = field_name
         body["viewName"] = view_name
         response = requests.post(url, headers=self.headers, json=body)
@@ -369,7 +380,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.field_url(model_id, view_name, field_name)
+        url = self._field_url(model_id, view_name, field_name)
         response = requests.patch(url, headers=self.headers, json=body)
         response.raise_for_status()
         return response.json()
@@ -387,7 +398,7 @@ class OmniAPI:
         Raises:
             requests.exceptions.RequestException: If the API request fails.
         """
-        url = self.field_url(model_id, view_name, field_name)
+        url = self._field_url(model_id, view_name, field_name)
         response = requests.delete(url, headers=self.headers)
         response.raise_for_status()
         return response.json()
@@ -404,11 +415,7 @@ class OmniAPI:
             requests.exceptions.RequestException: If the API request fails.
         """
         url = f"{self.base_url}/api/scim/v2/users"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.post(url, headers=headers, json=body)
+        response = requests.post(url, headers=self.headers, json=body)
         response.raise_for_status()
         return response
 
@@ -425,11 +432,7 @@ class OmniAPI:
             requests.exceptions.RequestException: If the API request fails.
         """
         url = f"{self.base_url}/api/scim/v2/users/{id}"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.put(url, headers=headers, json=body)
+        response = requests.put(url, headers=self.headers, json=body)
         response.raise_for_status()
         return response
 
@@ -445,11 +448,7 @@ class OmniAPI:
             requests.exceptions.RequestException: If the API request fails.
         """
         url = f"{self.base_url}/api/scim/v2/users"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.get(url, headers=headers, params={'filter': f'userName eq "{email}"'})
+        response = requests.get(url, headers=self.headers, params={'filter': f'userName eq "{email}"'})
         response.raise_for_status()
         return response
     
@@ -524,11 +523,7 @@ class OmniAPI:
             requests.Response: The response object from the delete operation.
         """
         url = f"{self.base_url}/api/scim/v2/users"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.delete(f"{url}/{id}", headers=headers)
+        response = requests.delete(f"{url}/{id}", headers=self.headers)
         response.raise_for_status()
         return response
 
@@ -542,11 +537,7 @@ class OmniAPI:
             dict: The exported document data as a dictionary.
         """
         url = f"{self.base_url}/api/unstable/documents/{id}/export"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.get(url,headers=headers)
+        response = requests.get(url,headers=self.headers)
         response.raise_for_status()
         return response.json()
 
@@ -560,11 +551,7 @@ class OmniAPI:
             requests.Response: The response object from the import operation.
         """
         url = f"{self.base_url}/api/unstable/documents/import"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.post(url,headers=headers, json=body)
+        response = requests.post(url,headers=self.headers, json=body)
         response.raise_for_status()
         return response
 
@@ -578,12 +565,8 @@ class OmniAPI:
             dict: A dictionary containing the list of folders.
         """
         url = f"{self.base_url}/api/unstable/folders"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
         response = requests.get(url, 
-                                headers=headers, 
+                                headers=self.headers, 
                                 params={
                                     'path': path,
                                     }
@@ -601,12 +584,8 @@ class OmniAPI:
             dict: A dictionary containing the list of documents.
         """
         url = f"{self.base_url}/api/unstable/documents"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
         response = requests.get(url, 
-                                headers=headers, 
+                                headers=self.headers, 
                                 params={
                                     'folderId': folderId if folderId else None,
                                     }
@@ -641,10 +620,6 @@ class OmniAPI:
             requests.Response: The response object containing the generated embed URL.
         """
         url = f"{self.base_url}/embed/sso/generate-url"
-        headers = {
-            'Authorization': f'Bearer {self.api_key}',
-            'Content-Type': 'application/json'
-        }
-        response = requests.post(url, headers=headers, json=body)
+        response = requests.post(url, headers=self.headers, json=body)
         response.raise_for_status()
         return response

--- a/omni_python_sdk/api.py
+++ b/omni_python_sdk/api.py
@@ -9,7 +9,25 @@ import base64
 from typing import List, Tuple, Any
 
 class OmniAPI:
+    """
+    A class to interact with the Omni API.
+
+    This class provides methods to perform various operations such as running queries,
+    managing models, topics, views, fields, and users.
+
+    Attributes:
+        api_key (str): The API key for authentication.
+        base_url (str): The base URL for the API.
+        headers (dict): The headers used for API requests.
+    """
+
     def __init__(self, api_key: str, base_url: str = "https://dev.thundersalmon.com/api/unstable"):
+        """
+        Initialize the OmniAPI instance.
+        Args:
+            api_key (str): The API key for authentication.
+            base_url (str, optional): The base URL for the API. Defaults to "https://dev.thundersalmon.com/api/unstable".
+        """
         self.api_key = api_key
         self.base_url = base_url
         self.headers = {
@@ -17,7 +35,16 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
 
-    def wait_query_blocking(self, remaining_job_ids:  List[str]) -> Tuple[Any, bool]:
+    def wait_query_blocking(self, remaining_job_ids: List[str]) -> Tuple[Any, bool]:
+        """
+        Wait for query jobs to complete.
+        Args:
+            remaining_job_ids (List[str]): List of job IDs to wait for.
+        Returns:
+            Tuple[Any, bool]: A tuple containing the response JSON and a boolean indicating if the jobs are done.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = f"{self.base_url}/query/wait"
         
         # URL encode the query parameter
@@ -32,8 +59,18 @@ class OmniAPI:
             return response_json, done
         else:
             response.raise_for_status()
-    
-    def run_query_blocking(self, body: dict):
+
+    def run_query_blocking(self, body: dict) -> Tuple[pa.Table, List[dict]]:
+        """
+        Run a query and wait for its completion.
+        Args:
+            body (dict): The query body.
+        Returns:
+            Tuple[pa.Table, List[dict]]: A tuple containing the result table and field information.
+        Raises:
+            ValueError: If no result is found in the response.
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = f"{self.base_url}/query/run"
         response = requests.post(url, headers=self.headers, json=body)
     
@@ -57,88 +94,264 @@ class OmniAPI:
                 raise ValueError("No result found in the response.")
         else:
             response.raise_for_status()
-    
-    def base_model_url(self):
+
+    def base_model_url(self) -> str:
+        """
+        Get the base URL for model operations.
+        Returns:
+            str: The base URL for model operations.
+        """
         return f"{self.base_url}/model"
-    
-    def model_url(self, model_id: str):
+
+    def model_url(self, model_id: str) -> str:
+        """
+        Get the URL for a specific model.
+        Args:
+            model_id (str): The ID of the model.
+        Returns:
+            str: The URL for the specified model.
+        """
         return f"{self.base_model_url()}/{model_id}"
-    
-    def base_topic_url(self, model_id: str):
+
+    def base_topic_url(self, model_id: str) -> str:
+        """
+        Get the base URL for topic operations.
+        Args:
+            model_id (str): The ID of the model.
+        Returns:
+            str: The base URL for topic operations.
+        """
         return f"{self.base_model_url()}/{model_id}/topic"
-    
-    def topic_url(self, model_id: str, topic_name: str):
+
+    def topic_url(self, model_id: str, topic_name: str) -> str:
+        """
+        Get the URL for a specific topic.
+        Args:
+            model_id (str): The ID of the model.
+            topic_name (str): The name of the topic.
+        Returns:
+            str: The URL for the specified topic.
+        """
         return f"{self.base_topic_url(model_id)}/{topic_name}"
 
-    def base_view_url(self, model_id: str):
+    def base_view_url(self, model_id: str) -> str:
+        """
+        Get the base URL for view operations.
+        Args:
+            model_id (str): The ID of the model.
+        Returns:
+            str: The base URL for view operations.
+        """
         return f"{self.base_model_url()}/{model_id}/view"
 
-    def view_url(self, model_id: str, view_name: str):
+    def view_url(self, model_id: str, view_name: str) -> str:
+        """
+        Get the URL for a specific view.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view.
+        Returns:
+            str: The URL for the specified view.
+        """
         return f"{self.base_view_url(model_id)}/{view_name}"
 
-    def base_field_url(self, model_id: str):
+    def base_field_url(self, model_id: str) -> str:
+        """
+        Get the base URL for field operations.
+        Args:
+            model_id (str): The ID of the model.
+        Returns:
+            str: The base URL for field operations.
+        """
         return f"{self.base_view_url(model_id)}/field"
-    
-    def field_url(self, model_id: str, view_name: str, field_name: str):
+
+    def field_url(self, model_id: str, view_name: str, field_name: str) -> str:
+        """
+        Get the URL for a specific field.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view.
+            field_name (str): The name of the field.
+        Returns:
+            str: The URL for the specified field.
+        """
         return f"{self.view_url(model_id, view_name)}/field/{field_name}"
 
-    def create_model(self, connection_id: str, body: dict):
+    def create_model(self, connection_id: str, body: dict) -> dict:
+        """
+        Create a new model.
+        Args:
+            connection_id (str): The connection ID.
+            body (dict): The model creation body.
+        Returns:
+            dict: The created model information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.base_model_url()
         body["connectionId"] = connection_id
         response = requests.post(url, headers=self.headers, json=body)
         return response.json()
 
-    def create_topic(self, model_id: str, base_view_name: str, body: dict):
+    def create_topic(self, model_id: str, base_view_name: str, body: dict) -> dict:
+        """
+        Create a new topic.
+        Args:
+            model_id (str): The ID of the model.
+            base_view_name (str): The name of the base view.
+            body (dict): The topic creation body.
+        Returns:
+            dict: The created topic information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.base_topic_url(model_id)
         body["baseViewName"] = base_view_name
         response = requests.post(url, headers=self.headers, json=body)
         return response.json()
 
-    def update_topic(self, model_id: str, topic_name: str, body: dict):
+    def update_topic(self, model_id: str, topic_name: str, body: dict) -> dict:
+        """
+        Update an existing topic.
+        Args:
+            model_id (str): The ID of the model.
+            topic_name (str): The name of the topic to update.
+            body (dict): The topic update body.
+        Returns:
+            dict: The updated topic information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.topic_url(model_id, topic_name)
         response = requests.patch(url, headers=self.headers, json=body)
         return response.json()
 
-    def delete_topic(self, model_id: str, topic_name: str):
+    def delete_topic(self, model_id: str, topic_name: str) -> dict:
+        """
+        Delete a topic.
+        Args:
+            model_id (str): The ID of the model.
+            topic_name (str): The name of the topic to delete.
+        Returns:
+            dict: The response from the delete operation.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.topic_url(model_id, topic_name)
         response = requests.delete(url, headers=self.headers)
         return response.json()
 
-    def create_view(self, model_id: str, view_name: str, body: dict):
+    def create_view(self, model_id: str, view_name: str, body: dict) -> dict:
+        """
+        Create a new view.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view to create.
+            body (dict): The view creation body.
+        Returns:
+            dict: The created view information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.base_view_url(model_id)
         body["viewName"] = view_name
         response = requests.post(url, headers=self.headers, json=body)
         return response.json()
-    
-    def update_view(self, model_id: str, view_name: str, body: dict):
+
+    def update_view(self, model_id: str, view_name: str, body: dict) -> dict:
+        """
+        Update an existing view.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view to update.
+            body (dict): The view update body.
+        Returns:
+            dict: The updated view information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.view_url(model_id, view_name)
         body["viewName"] = view_name
         response = requests.patch(url, headers=self.headers, json=body)
         return response.json()
-    
-    def delete_view(self, model_id: str, view_name: str):
+
+    def delete_view(self, model_id: str, view_name: str) -> dict:
+        """
+        Delete a view.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view to delete.
+        Returns:
+            dict: The response from the delete operation.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.view_url(model_id, view_name)
         response = requests.delete(url, headers=self.headers)
         return response.json()
 
-    def create_field(self, model_id: str, view_name: str, field_name: str, body: dict):
+    def create_field(self, model_id: str, view_name: str, field_name: str, body: dict) -> dict:
+        """
+        Create a new field.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view.
+            field_name (str): The name of the field to create.
+            body (dict): The field creation body.
+        Returns:
+            dict: The created field information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.base_field_url(model_id)
         body["fieldName"] = field_name
         body["viewName"] = view_name
         response = requests.post(url, headers=self.headers, json=body)
         return response.json()
 
-    def update_field(self, model_id: str, view_name: str, field_name: str, body: dict):
+    def update_field(self, model_id: str, view_name: str, field_name: str, body: dict) -> dict:
+        """
+        Update an existing field.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view.
+            field_name (str): The name of the field to update.
+            body (dict): The field update body.
+        Returns:
+            dict: The updated field information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.field_url(model_id, view_name, field_name)
         response = requests.patch(url, headers=self.headers, json=body)
         return response.json()
 
-    def delete_field(self, model_id: str, view_name: str, field_name: str):
+    def delete_field(self, model_id: str, view_name: str, field_name: str) -> dict:
+        """
+        Delete a field.
+        Args:
+            model_id (str): The ID of the model.
+            view_name (str): The name of the view.
+            field_name (str): The name of the field to delete.
+        Returns:
+            dict: The response from the delete operation.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = self.field_url(model_id, view_name, field_name)
         response = requests.delete(url, headers=self.headers)
         return response.json()
-    
-    def create_user(self, body:dict):
+
+    def create_user(self, body: dict) -> requests.Response:
+        """
+        Create a new user.
+        Args:
+            body (dict): The user creation body.
+        Returns:
+            requests.Response: The response from the create operation.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = f"{self.base_url}/api/scim/v2/users"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -146,8 +359,18 @@ class OmniAPI:
         }
         response = requests.post(url, headers=headers, json=body)
         return response
-    
-    def update_user(self, id, body:dict):
+
+    def update_user(self, id: str, body: dict) -> requests.Response:
+        """
+        Update an existing user.
+        Args:
+            id (str): The ID of the user to update.
+            body (dict): The user update body.
+        Returns:
+            requests.Response: The response from the update operation.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = f"{self.base_url}/api/scim/v2/users/{id}"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -155,8 +378,17 @@ class OmniAPI:
         }
         response = requests.put(url, headers=headers, json=body)
         return response
-    
-    def find_user_by_email(self, email:str):
+
+    def find_user_by_email(self, email: str) -> requests.Response:
+        """
+        Find a user by email.
+        Args:
+            email (str): The email of the user to find.
+        Returns:
+            requests.Response: The response containing the user information.
+        Raises:
+            requests.exceptions.RequestException: If the API request fails.
+        """
         url = f"{self.base_url}/api/scim/v2/users"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -166,6 +398,17 @@ class OmniAPI:
         return response
     
     def upsert_user(self, email:str, displayName:str, attributes:dict):
+        """
+        Create a new user or update an existing user's information.
+        Args:
+            email (str): The email address of the user.
+            displayName (str): The display name for the user.
+            attributes (dict): Additional attributes for the user.
+        Returns:
+            None
+        Prints:
+            Status messages about the operation's success or failure.
+        """
         body ={
             "urn:omni:params:1.0:UserAttribute":self.listify(attributes)
         }
@@ -192,6 +435,15 @@ class OmniAPI:
                 print(f'{len(users)} found for {email}, no action taken')
 
     def delete_user(self, email):
+        """
+        Delete a user by their email address.
+        Args:
+            email (str): The email address of the user to delete.
+        Returns:
+            requests.Response: The response object if the user is successfully deleted.
+        Prints:
+            Status messages about the operation's success or failure.
+        """
         users = self.find_user_by_email(email).json()['Resources']
         if len(users) == 1:
             user = users[0]
@@ -207,6 +459,13 @@ class OmniAPI:
             print(f'user {email} not found')
 
     def delete_user_by_id(self, id:str):
+        """
+        Delete a user by their user ID.
+        Args:
+            id (str): The ID of the user to delete.
+        Returns:
+            requests.Response: The response object from the delete operation.
+        """
         url = f"{self.base_url}/api/scim/v2/users"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -214,8 +473,15 @@ class OmniAPI:
         }
         response = requests.delete(f"{url}/{id}", headers=headers)
         return response
-    
+
     def document_export(self, id:str)->dict:
+        """
+        Export a document by its ID.
+        Args:
+            id (str): The ID of the document to export.
+        Returns:
+            dict: The exported document data as a dictionary.
+        """
         url = f"{self.base_url}/api/unstable/documents/{id}/export"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -225,6 +491,13 @@ class OmniAPI:
         return response.json()
 
     def document_import(self, body:dict):
+        """
+        Import a document.
+        Args:
+            body (dict): The document data to import.
+        Returns:
+            requests.Response: The response object from the import operation.
+        """
         url = f"{self.base_url}/api/unstable/documents/import"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -232,8 +505,15 @@ class OmniAPI:
         }
         response = requests.post(url,headers=headers, json=body)
         return response
-    
+
     def list_folders(self, path:str='') -> dict:
+        """
+        List folders at the specified path.
+        Args:
+            path (str, optional): The path to list folders from. Defaults to an empty string.
+        Returns:
+            dict: A dictionary containing the list of folders.
+        """
         url = f"{self.base_url}/api/unstable/folders"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -246,8 +526,15 @@ class OmniAPI:
                                     }
                                 )
         return response.json()
-    
+
     def list_documents(self, folderId:str='') -> dict:
+        """
+        List documents in the specified folder.
+        Args:
+            folderId (str, optional): The ID of the folder to list documents from. Defaults to an empty string.
+        Returns:
+            dict: A dictionary containing the list of documents.
+        """
         url = f"{self.base_url}/api/unstable/documents"
         headers = {
             'Authorization': f'Bearer {self.api_key}',
@@ -260,9 +547,16 @@ class OmniAPI:
                                     }
                                 )
         return response.json() 
-    
+
     @classmethod
     def listify(cls, d:dict) -> dict:
+        """
+        Convert string representations of lists in a dictionary to actual lists.
+        Args:
+            d (dict): The input dictionary.
+        Returns:
+            dict: A new dictionary with string representations of lists converted to actual lists.
+        """
         out = {}
         for k,v in d.items():
             if '[' in v and ']' in v:
@@ -270,8 +564,15 @@ class OmniAPI:
             else:
                 out.update({k:v})
         return out
-    
+
     def generate_embed_url(self,body:dict) -> dict:
+        """
+        Generate an embed URL.
+        Args:
+            body (dict): The request body containing necessary information for generating the embed URL.
+        Returns:
+            requests.Response: The response object containing the generated embed URL.
+        """
         url = f"{self.base_url}/embed/sso/generate-url"
         headers = {
             'Authorization': f'Bearer {self.api_key}',

--- a/omni_python_sdk/api.py
+++ b/omni_python_sdk/api.py
@@ -7,6 +7,34 @@ import json
 import ndjson
 import base64
 from typing import List, Tuple, Any
+import functools
+
+def requests_error_handler(func):
+    """
+    Decorator to handle generic errors when raising a status
+    via `response.raise_for_status()`. It catches all exceptions that occur when 
+    calling the decorated function and prints an error message with exception details.
+    Args:
+        func (callable): The function to be decorated.
+    Returns:
+        wrapper (callable): A wrapper function that handles exceptions.
+    Raises:
+        None (handled internally)
+    Example Use:
+        @requests_error_handler
+        def get_data(url):
+            response = requests.get(url)
+            response.raise_for_status()
+            return response.json()
+    """
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            print(f"Request Failed: {e}")
+            return None
+    return wrapper
 
 class OmniAPI:
     """
@@ -35,6 +63,7 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
 
+    @requests_error_handler
     def wait_query_blocking(self, remaining_job_ids: List[str]) -> Tuple[Any, bool]:
         """
         Wait for query jobs to complete.
@@ -60,6 +89,7 @@ class OmniAPI:
         else:
             response.raise_for_status()
 
+    @requests_error_handler
     def run_query_blocking(self, body: dict) -> Tuple[pa.Table, List[dict]]:
         """
         Run a query and wait for its completion.
@@ -176,7 +206,8 @@ class OmniAPI:
             str: The URL for the specified field.
         """
         return f"{self.view_url(model_id, view_name)}/field/{field_name}"
-
+    
+    @requests_error_handler
     def create_model(self, connection_id: str, body: dict) -> dict:
         """
         Create a new model.
@@ -191,8 +222,10 @@ class OmniAPI:
         url = self.base_model_url()
         body["connectionId"] = connection_id
         response = requests.post(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def create_topic(self, model_id: str, base_view_name: str, body: dict) -> dict:
         """
         Create a new topic.
@@ -208,8 +241,10 @@ class OmniAPI:
         url = self.base_topic_url(model_id)
         body["baseViewName"] = base_view_name
         response = requests.post(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def update_topic(self, model_id: str, topic_name: str, body: dict) -> dict:
         """
         Update an existing topic.
@@ -224,8 +259,10 @@ class OmniAPI:
         """
         url = self.topic_url(model_id, topic_name)
         response = requests.patch(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def delete_topic(self, model_id: str, topic_name: str) -> dict:
         """
         Delete a topic.
@@ -239,8 +276,10 @@ class OmniAPI:
         """
         url = self.topic_url(model_id, topic_name)
         response = requests.delete(url, headers=self.headers)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def create_view(self, model_id: str, view_name: str, body: dict) -> dict:
         """
         Create a new view.
@@ -256,8 +295,10 @@ class OmniAPI:
         url = self.base_view_url(model_id)
         body["viewName"] = view_name
         response = requests.post(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def update_view(self, model_id: str, view_name: str, body: dict) -> dict:
         """
         Update an existing view.
@@ -273,8 +314,10 @@ class OmniAPI:
         url = self.view_url(model_id, view_name)
         body["viewName"] = view_name
         response = requests.patch(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def delete_view(self, model_id: str, view_name: str) -> dict:
         """
         Delete a view.
@@ -288,8 +331,10 @@ class OmniAPI:
         """
         url = self.view_url(model_id, view_name)
         response = requests.delete(url, headers=self.headers)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def create_field(self, model_id: str, view_name: str, field_name: str, body: dict) -> dict:
         """
         Create a new field.
@@ -307,8 +352,10 @@ class OmniAPI:
         body["fieldName"] = field_name
         body["viewName"] = view_name
         response = requests.post(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def update_field(self, model_id: str, view_name: str, field_name: str, body: dict) -> dict:
         """
         Update an existing field.
@@ -324,8 +371,10 @@ class OmniAPI:
         """
         url = self.field_url(model_id, view_name, field_name)
         response = requests.patch(url, headers=self.headers, json=body)
+        response.raise_for_status()
         return response.json()
-
+    
+    @requests_error_handler
     def delete_field(self, model_id: str, view_name: str, field_name: str) -> dict:
         """
         Delete a field.
@@ -340,8 +389,10 @@ class OmniAPI:
         """
         url = self.field_url(model_id, view_name, field_name)
         response = requests.delete(url, headers=self.headers)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def create_user(self, body: dict) -> requests.Response:
         """
         Create a new user.
@@ -358,8 +409,10 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.post(url, headers=headers, json=body)
+        response.raise_for_status()
         return response
 
+    @requests_error_handler
     def update_user(self, id: str, body: dict) -> requests.Response:
         """
         Update an existing user.
@@ -377,8 +430,10 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.put(url, headers=headers, json=body)
+        response.raise_for_status()
         return response
 
+    @requests_error_handler
     def find_user_by_email(self, email: str) -> requests.Response:
         """
         Find a user by email.
@@ -395,6 +450,7 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.get(url, headers=headers, params={'filter': f'userName eq "{email}"'})
+        response.raise_for_status()
         return response
     
     def upsert_user(self, email:str, displayName:str, attributes:dict):
@@ -458,6 +514,7 @@ class OmniAPI:
         elif len(users) == 0:
             print(f'user {email} not found')
 
+    @requests_error_handler
     def delete_user_by_id(self, id:str):
         """
         Delete a user by their user ID.
@@ -472,8 +529,10 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.delete(f"{url}/{id}", headers=headers)
+        response.raise_for_status()
         return response
 
+    @requests_error_handler
     def document_export(self, id:str)->dict:
         """
         Export a document by its ID.
@@ -488,8 +547,10 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.get(url,headers=headers)
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def document_import(self, body:dict):
         """
         Import a document.
@@ -504,8 +565,10 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.post(url,headers=headers, json=body)
+        response.raise_for_status()
         return response
 
+    @requests_error_handler
     def list_folders(self, path:str='') -> dict:
         """
         List folders at the specified path.
@@ -525,8 +588,10 @@ class OmniAPI:
                                     'path': path,
                                     }
                                 )
+        response.raise_for_status()
         return response.json()
 
+    @requests_error_handler
     def list_documents(self, folderId:str='') -> dict:
         """
         List documents in the specified folder.
@@ -546,6 +611,7 @@ class OmniAPI:
                                     'folderId': folderId if folderId else None,
                                     }
                                 )
+        response.raise_for_status()
         return response.json() 
 
     @classmethod
@@ -565,6 +631,7 @@ class OmniAPI:
                 out.update({k:v})
         return out
 
+    @requests_error_handler
     def generate_embed_url(self,body:dict) -> dict:
         """
         Generate an embed URL.
@@ -579,4 +646,5 @@ class OmniAPI:
             'Content-Type': 'application/json'
         }
         response = requests.post(url, headers=headers, json=body)
+        response.raise_for_status()
         return response

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ ndjson
 pandas
 matplotlib
 statsmodels
-omni_python_sdk
+load-dotenv

--- a/setup.py
+++ b/setup.py
@@ -2,26 +2,23 @@ from setuptools import setup, find_packages
 
 setup(
 	name='omni_python_sdk',
-	version='0.1.5',
+	version='0.1.6',
 	description='A Python SDK for Omni API',
 	long_description=open('README.md').read(),
 	long_description_content_type='text/markdown',
 	author='Jamie Davidson',
 	author_email='jamie@omni.co',
-	url='https://github.com/yourusername/omni-python-sdk',
+	url='https://github.com/exploreomni/omni-python-sdk',
 	packages=find_packages(),
 	install_requires=[
 		'requests',
 		'pyarrow',
-		'ndjson',
-		'pandas',
-		'matplotlib',
-		'statsmodels'
+		'ndjson'
 	],
 	classifiers=[
 		'Programming Language :: Python :: 3',
 		'License :: OSI Approved :: MIT License',
 		'Operating System :: OS Independent',
 	],
-	python_requires='>=3.6',
+	python_requires='>=3.9',
 )


### PR DESCRIPTION
# Summary
In the last couple of weeks, I created a version of the now live `OmniAPI` class for internal use at Curaleaf. My initial implementation was just Russ' code, with added docstrings, added exception handling, and wrapping it all up into a pip-installable package for our developers to use. 

Now that Omni is [maintaining](https://community.omni.co/t/bulk-user-and-user-attribute-management/253) their own tried and true utility, my team at Curaleaf decided to forgo the use of our internal `omni-users` package and instead, opt to use the official `omni-python-sdk`!

I'm opening this PR to contribute some previous work I did for our internal implementation. The suggested additions are very simple and are fully open to further suggestions, modifications, and rejection lol. 

# Details
1. Added docstrings to the `OmniAPI` class and methods
2. Added a decorator, `@requests_error_handler`, to wrap around the functions that raise a status for a request response. This is mainly to:
    - Catch/handle requests exceptions in a simple and consistent way
    - Print out the error to the user closer to where an exception is raised
    - Prevent propagation of exceptions thru the call stack (related to 2nd bullet)

This is just a friendly suggestion and hopefully a way to contribute! No pressure to approve or merge :)